### PR TITLE
Add landing page to navigate between assistant and chat apps

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Plateforme P-2 : Feedback Réflexif</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="main-container">
+        <header>
+            <div class="logo-container">
+                <img src="logo.png" alt="Logo" class="logo">
+                <span class="foundation-name">Fondation Léonie Chaptal</span>
+            </div>
+            <h1>Plateforme P-2 : Atelier de Feedback Réflexif</h1>
+            <nav class="nav-links">
+                <a href="/">Accueil</a>
+                <a href="/assistant">Assistant</a>
+            </nav>
+        </header>
+
+        <div class="scenario-banner">
+            <p><strong>Contexte :</strong> Qu'est-ce que tu peux connaître à propos du diagnostic de maladie</p>
+        </div>
+
+        <main class="chat-container">
+            <div class="split-panel">
+                <!-- Left Panel - Actual Prompt -->
+                <div class="panel actual-prompt-panel">
+                    <h2 class="panel-title">Prompt Actuel</h2>
+                    <div class="chat-window">
+                        <div class="chat-message user">
+                            <div class="message-header">Prompt initial</div>
+                            <div class="message-content">"Le patient a de la fièvre."</div>
+                            <div class="score score-low">Score Qualité : 0.62</div>
+                        </div>
+                        
+                        <div class="chat-message ai">
+                            <div class="message-header">Réponse générée</div>
+                            <div class="message-content">"La fièvre peut être causée par de nombreuses pathologies, allant d'infections virales bénignes à des conditions plus sérieuses. Sans informations complémentaires comme la durée, l'intensité de la fièvre ou d'autres symptômes associés, il est difficile d'établir un diagnostic précis. Je recommanderais de surveiller la température, de vérifier la présence d'autres symptômes et de consulter si la fièvre persiste plus de trois jours ou dépasse 39°C."</div>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Right Panel - Best Prompt -->
+                <div class="panel best-prompt-panel">
+                    <h2 class="panel-title">Prompt Optimisé</h2>
+                    <div class="chat-window">
+                        <div class="chat-message reference">
+                            <div class="message-header">Référence optimisée</div>
+                            <div class="message-content">
+                                <p><strong>Prompt optimisé :</strong> "Bonjour M. Martin, nous avons reçu les résultats. J'aimerais prendre le temps d'en discuter avec vous. Comment vous sentez-vous depuis notre dernière rencontre ?"</p>
+                                <p><strong>Réponse de référence :</strong> "Bonjour Docteur. Pour être honnête, je suis assez nerveux. J'espère que ce n'est pas trop grave. Qu'est-ce que ces résultats disent ?"</p>
+                            </div>
+                            <div class="score score-high">Score Qualité : 0.91</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <footer>
+            <div class="input-container">
+                <textarea id="user-input" placeholder="Tapez un message ou utilisez..."></textarea>
+                <button class="send-button">SEND</button>
+                <button class="voice-button">Parlez</button>
+            </div>
+            <div class="tools">
+                <button class="tool-button search-button"></button>
+                <button class="tool-button camera-button"></button>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,73 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Plateforme P-2 : Feedback Réflexif</title>
+    <title>Plateforme P-2</title>
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
-    <div class="main-container">
-        <header>
-            <div class="logo-container">
-                <img src="logo.png" alt="Logo" class="logo">
-                <span class="foundation-name">Fondation Léonie Chaptal</span>
-            </div>
-            <h1>Plateforme P-2 : Atelier de Feedback Réflexif</h1>
-        </header>
-
-        <div class="scenario-banner">
-            <p><strong>Contexte :</strong> Qu'est-ce que tu peux connaître à propos du diagnostic de maladie</p>
+    <div class="home-container">
+        <h1>Bienvenue sur la plateforme P-2</h1>
+        <div class="home-buttons">
+            <a class="home-button" href="/assistant">Assistant Virtuel</a>
+            <a class="home-button" href="/chat">Chat</a>
         </div>
-
-        <main class="chat-container">
-            <div class="split-panel">
-                <!-- Left Panel - Actual Prompt -->
-                <div class="panel actual-prompt-panel">
-                    <h2 class="panel-title">Prompt Actuel</h2>
-                    <div class="chat-window">
-                        <div class="chat-message user">
-                            <div class="message-header">Prompt initial</div>
-                            <div class="message-content">"Le patient a de la fièvre."</div>
-                            <div class="score score-low">Score Qualité : 0.62</div>
-                        </div>
-                        
-                        <div class="chat-message ai">
-                            <div class="message-header">Réponse générée</div>
-                            <div class="message-content">"La fièvre peut être causée par de nombreuses pathologies, allant d'infections virales bénignes à des conditions plus sérieuses. Sans informations complémentaires comme la durée, l'intensité de la fièvre ou d'autres symptômes associés, il est difficile d'établir un diagnostic précis. Je recommanderais de surveiller la température, de vérifier la présence d'autres symptômes et de consulter si la fièvre persiste plus de trois jours ou dépasse 39°C."</div>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Right Panel - Best Prompt -->
-                <div class="panel best-prompt-panel">
-                    <h2 class="panel-title">Prompt Optimisé</h2>
-                    <div class="chat-window">
-                        <div class="chat-message reference">
-                            <div class="message-header">Référence optimisée</div>
-                            <div class="message-content">
-                                <p><strong>Prompt optimisé :</strong> "Bonjour M. Martin, nous avons reçu les résultats. J'aimerais prendre le temps d'en discuter avec vous. Comment vous sentez-vous depuis notre dernière rencontre ?"</p>
-                                <p><strong>Réponse de référence :</strong> "Bonjour Docteur. Pour être honnête, je suis assez nerveux. J'espère que ce n'est pas trop grave. Qu'est-ce que ces résultats disent ?"</p>
-                            </div>
-                            <div class="score score-high">Score Qualité : 0.91</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </main>
-
-        <footer>
-            <div class="input-container">
-                <textarea id="user-input" placeholder="Tapez un message ou utilisez..."></textarea>
-                <button class="send-button">SEND</button>
-                <button class="voice-button">Parlez</button>
-            </div>
-            <div class="tools">
-                <button class="tool-button search-button"></button>
-                <button class="tool-button camera-button"></button>
-            </div>
-        </footer>
     </div>
 </body>
 </html>

--- a/r3f-virtual-girlfriend-frontend/src/components/UI.jsx
+++ b/r3f-virtual-girlfriend-frontend/src/components/UI.jsx
@@ -28,6 +28,10 @@ export const UI = ({ hidden, ...props }) => {
           <span className="text-lg font-semibold text-chaptal-purple">
             Fondation Léonie Chaptal
           </span>
+          <nav className="ml-4 flex gap-2">
+            <a href="/" className="px-2 py-1 bg-chaptal-green text-white rounded">Accueil</a>
+            <a href="/chat" className="px-2 py-1 bg-chaptal-green text-white rounded">Chat</a>
+          </nav>
         </div>
         <div className="w-full flex flex-col items-end justify-center gap-4">
           <button

--- a/shared-backend/index.js
+++ b/shared-backend/index.js
@@ -15,7 +15,7 @@ app.get('/', (req, res) => {
 
 // Chat page
 app.get('/chat', (req, res) => {
-  res.sendFile(path.join(__dirname, '../chatgpt-simulation.html'));
+  res.sendFile(path.join(__dirname, '../chat.html'));
 });
 
 // Assistant static build

--- a/style.css
+++ b/style.css
@@ -22,6 +22,41 @@ body {
     color: var(--text-color);
 }
 
+.home-container {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+    text-align: center;
+}
+
+.home-buttons {
+    display: flex;
+    gap: 20px;
+}
+
+.home-button {
+    padding: 15px 25px;
+    background-color: var(--secondary-color);
+    color: white;
+    border-radius: 5px;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.nav-links a {
+    margin-left: 15px;
+    color: var(--primary-color);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.nav-links a:hover {
+    text-decoration: underline;
+}
+
 .main-container {
     max-width: 100%;
     min-height: 100vh;


### PR DESCRIPTION
## Summary
- Add new home landing page with links to the virtual assistant and chat app
- Update chat page, React UI, and backend routes for cross-navigation
- Style navigation elements for consistent appearance

## Testing
- `npm test` in `r3f-virtual-girlfriend-frontend` *(fails: Missing script)*
- `npm test` in `r3f-virtual-girlfriend-backend` *(fails: Missing script)*
- `npm test` in `shared-backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a4781d525083299ce6be1a7b4c8069