### PR TITLE
Fix navigation buttons in assistant UI

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -18,7 +18,7 @@
             </div>
             <h1>Plateforme P-2 : Atelier de Feedback Réflexif</h1>
             <nav class="nav-links">
-                <a href="/">Accueil</a>
+                <a href="index.html">Accueil</a>
                 <a href="/assistant">Assistant</a>
             </nav>
         </header>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <h1>Bienvenue sur la plateforme P-2</h1>
         <div class="home-buttons">
             <a class="home-button" href="/assistant">Assistant Virtuel</a>
-            <a class="home-button" href="/chat">Chat</a>
+            <a class="home-button" href="chat.html">Chat</a>
         </div>
     </div>
 </body>

--- a/r3f-virtual-girlfriend-frontend/src/components/UI.jsx
+++ b/r3f-virtual-girlfriend-frontend/src/components/UI.jsx
@@ -19,7 +19,7 @@ export const UI = ({ hidden, ...props }) => {
   return (
     <>
       <div className="fixed top-0 left-0 right-0 bottom-0 z-10 flex justify-between p-4 flex-col pointer-events-none">
-      <div className="self-start backdrop-blur-md bg-white bg-opacity-50 p-4 rounded-lg flex items-center gap-2">
+      <div className="self-start pointer-events-auto backdrop-blur-md bg-white bg-opacity-50 p-4 rounded-lg flex items-center gap-2">
           <img
             src="images/logo-chaptal.png"
             alt="Fondation Léonie Chaptal"
@@ -29,8 +29,8 @@ export const UI = ({ hidden, ...props }) => {
             Fondation Léonie Chaptal
           </span>
           <nav className="ml-4 flex gap-2">
-            <a href="/" className="px-2 py-1 bg-chaptal-green text-white rounded">Accueil</a>
-            <a href="/chat" className="px-2 py-1 bg-chaptal-green text-white rounded">Chat</a>
+            <a href="/index.html" className="px-2 py-1 bg-chaptal-green text-white rounded">Accueil</a>
+            <a href="/chat.html" className="px-2 py-1 bg-chaptal-green text-white rounded">Chat</a>
           </nav>
         </div>
         <div className="w-full flex flex-col items-end justify-center gap-4">


### PR DESCRIPTION
## Summary
- link assistant header buttons to index.html and chat.html for page navigation
- update home and chat pages so their buttons navigate correctly between apps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47c3e51b08329a322b11203294dc8